### PR TITLE
Improve contribute section style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,8 @@ you can find the list of contributors on the [contributors page](https://github.
 
 
 ## Team
+<a href="https://github.com/EvolveBeyond/nvpak/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=EvolveBeyond/nvpak" />
+</a>
 
-| ![pakrohk](https://github.com/Pakrohk.png?size=71) | ![ARS101](https://github.com/ARS101.png?size=71) | ![lorem10](https://github.com/lorem10.png?size=71) | ![nooob-developer](https://github.com/nooob-developer.png?size=71) |
-| :-----------------------------------------------: | :------------------------------------------------------: | :-------------------------------------: | :--------------: |
-| [Pakrohk](https://github.com/Pakrohk) | [ARS101](https://github.com/ARS101) | [lorem10](https://github.com/lorem10) | [nooob-developer](https://github.com/nooob-developer) |
-
-| [H-cyber](https://github.com/H-cyber.png?size=74) | ![mandarvaze](https://github.com/mandarvaze.png?size=74) | ![RealMrHex](https://github.com/RealMrHex.png?size=74) | ![0xj0hn](https://github.com/0xj0hn.png?size=74) |
-| :-----------------------------------------------: | :------------------------------------------------------: | :-------------------------------------: | :----------------: |
-| [H-cyber](https://github.com/H-cyber) | [mandarvaze](https://github.com/mandarvaze) | [RealMrHex](https://github.com/RealMrHex) | [0xj0hn](https://github.com/0xj0hn) |
 


### PR DESCRIPTION
In this pull request, I have improved the style of the contribute section in the README file. For this update, I used **contrib.rocks** and applied the following changes

**Before**
> ![image](https://github.com/user-attachments/assets/282cd064-3eff-4511-9576-707396b28490)


**After**
> ![image](https://github.com/user-attachments/assets/02b945f2-1939-49ef-a183-c06e8c588157)
