### PR TITLE
fix nvim-terminal plugin

### DIFF
--- a/lua/plugins/ui/nvim-terminal/config.lua
+++ b/lua/plugins/ui/nvim-terminal/config.lua
@@ -9,4 +9,4 @@ local window = Window:new({
 })
 
 local terminal = Terminal:new(window)
-require("packages.ui.nvim-terminal.bind") -- bindings
+require("plugins.ui.nvim-terminal.bind") -- bindings

--- a/lua/plugins/ui/nvim-terminal/init.lua
+++ b/lua/plugins/ui/nvim-terminal/init.lua
@@ -1,8 +1,0 @@
-return {
-		"s1n7ax/nvim-terminal",
-		event = { "BufRead" },
-		config = function()
-			require("packages.ui.nvim-terminal.main")
-		end,
-	}
-

--- a/rocks.toml
+++ b/rocks.toml
@@ -33,6 +33,9 @@ catppuccin = "0.1.0"
 "telescope-ui-select.nvim" = "scm"
 "telescope.nvim" = "scm"
 
+[plugins.nvim-terminal]
+git = "s1n7ax/nvim-terminal"
+config = "plugins.ui.nvim-terminal.config"
 [plugins.cmp-nvim-lua]
 git = "hrsh7th/cmp-nvim-lua"
 [plugins.cmp-spell]


### PR DESCRIPTION
The plugin was added to rocks.toml as a Git source, the init.lua file from lazy was removed, and the paths were replaced in the configuration.