### PR TITLE
fix(cmp): improve comparator order for better match accuracy

### DIFF
--- a/lua/plugins/autocomplete/cmp/sorting.lua
+++ b/lua/plugins/autocomplete/cmp/sorting.lua
@@ -3,14 +3,14 @@ local function setup_sorting(cmp, compare)
 		sorting = {
 			priority_weight = 1.0,
 			comparators = {
-				compare.recently_used, -- prioritizes recently used items
-				compare.kind, -- prioritizes items with the same kind
 				compare.offset, -- prioritizes items closer to the cursor
-				compare.order, -- prioritizes items in the same received order
-				compare.sort_text, -- prioritizes prefix matches within completion items
-				compare.length, -- prioritizes shorter completion items
 				compare.exact, -- prioritizes items starting with exactly the same prefix
 				compare.score, -- prioritizes item similarity score
+				compare.recently_used, -- prioritizes recently used items
+				compare.kind, -- prioritizes items with the same kind
+				compare.sort_text, -- prioritizes prefix matches within completion items
+				compare.length, -- prioritizes shorter completion items
+				compare.order, -- prioritizes items in the same received order
 			},
 			debug = {
 				priority = true,


### PR DESCRIPTION
The new order improves accuracy by prioritizing offset, exact, and score first.